### PR TITLE
Conformance matrix fuzzer configs

### DIFF
--- a/conformance-criteria/conformance-matrix.md
+++ b/conformance-criteria/conformance-matrix.md
@@ -18,7 +18,7 @@ Date: 2026-05-05
     * L1 -- Happy-path import: import without mutations or Safrole.
         - L1a -- Tiny spec
         - L1b -- Full spec
-    * L2 -- Mutations: happy-path import together with mutation/error handling, without Safrole.
+    * L2 -- Mutations: import with mutation/error handling, without Safrole.
         - L2a -- Tiny spec
         - L2b -- Full spec
     * L3 -- Safrole: exercise Safrole, no mutations.
@@ -73,7 +73,6 @@ Source: `fuzzer_configs/l1_tiny.toml`
 | max_steps | 100000 |
 | safrole | false |
 | skip_slots | false |
-| seeds | 10 random |
 
 ### L1b -- Full
 
@@ -89,7 +88,6 @@ Source: `fuzzer_configs/l1_full.toml`
 | max_steps | 100000 |
 | safrole | false |
 | skip_slots | false |
-| seeds | 10 random |
 
 ### Acceptance Criteria (L1a/L1b)
 
@@ -115,7 +113,6 @@ Source: `fuzzer_configs/l2_tiny.toml`
 | max_steps | 1000000 |
 | safrole | false |
 | skip_slots | false |
-| seeds | 10 random |
 
 ### L2b -- Full
 
@@ -132,7 +129,6 @@ Source: `fuzzer_configs/l2_full.toml`
 | max_steps | 1000000 |
 | safrole | false |
 | skip_slots | false |
-| seeds | 10 random |
 
 ### Acceptance Criteria (L2a/L2b)
 
@@ -157,7 +153,6 @@ Source: `fuzzer_configs/l3_tiny.toml`
 | max_work_items | 3 |
 | max_steps | 100000 |
 | skip_slots | false |
-| seeds | 10 random |
 
 ### L3b -- empty workload
 
@@ -165,7 +160,7 @@ Source: `fuzzer_configs/l3_full.toml`
 
 | Parameter | Value |
 |-----------|-------|
-| jam_spec | tiny |
+| jam_spec | full |
 | profile | empty |
 | fuzzy_profile | empty |
 | safrole | true |
@@ -173,7 +168,6 @@ Source: `fuzzer_configs/l3_full.toml`
 | max_work_items | 0 |
 | max_steps | 100000 |
 | skip_slots | false |
-| seeds | 10 random |
 
 ### Acceptance Criteria (L3a/L3b)
 

--- a/conformance-criteria/conformance-matrix.md
+++ b/conformance-criteria/conformance-matrix.md
@@ -7,6 +7,14 @@ Date: 2026-05-05
 - Ensure that a team's Jam implementation is conformant to the M1 milestone.
 - Define test programme that all teams have to satisfy with explicit parameters and acceptance criteria
 
+## Versions
+
+Conformance runs must use tooling matching the Gray Paper version targeted by the implementation. The accepted minimum is GP 0.7.2; later releases are accepted as their tooling rows are added below.
+
+| GP version | Fuzzer | jam-types-py |
+|------------|--------|--------------|
+| 0.7.2 | [`fuzzer-gp-0.7.2`](https://github.com/paritytech/polkajam/releases/tag/fuzzer-gp-0.7.2) | [`v0.7.2`](https://github.com/davxy/jam-types-py/releases/tag/v0.7.2) |
+
 ## Test structure
 
 - Teams have to satisfy different tests to cover as much as possible about the Jam specification.
@@ -46,9 +54,21 @@ Every session must additionally reach its configured `max_steps`.
 
 The wire-level message exchange (block submission, import / state-root / error responses) is defined by the fuzzer protocol; see [`../fuzz-proto/README.md`](../fuzz-proto/README.md) and [`../fuzz-proto/fuzz-v1.asn`](../fuzz-proto/fuzz-v1.asn).
 
+## Submission
+
+The implementor submits the target as a Docker image conforming to the [Standard Target Packaging](../fuzz-proto/README.md#standard-target-packaging) section of the fuzzer protocol. In summary:
+
+- `linux/amd64` Docker image, kept minimal.
+- Reads `JAM_FUZZ`, `JAM_FUZZ_SPEC`, `JAM_FUZZ_DATA_PATH` and `JAM_FUZZ_SOCK_PATH` from the environment (plus the optional `JAM_FUZZ_LOG_LEVEL`); refuses to start if any required variable is missing.
+- Listens on the configured Unix domain socket and supports multiple fuzzer sessions in sequence, with exactly one `Initialize` message per session.
+
+Each lane is run against the submitted image using the corresponding `fuzzer_configs/*.toml`. Resulting traces, reports and summaries are published under [`../fuzz-reports/<gp-version>/`](../fuzz-reports/); see [`../fuzz-reports/README.md`](../fuzz-reports/README.md) for the layout and team registry.
+
+The known test vectors lane requires no submission beyond the implementor's self-assessment.
+
 ## Known Test Vectors
 
-Run implementation against all published and well-known test vectors.
+Run the implementation against the published JAM test vectors at https://github.com/davxy/jam-test-vectors.
 
 ## L0 -- Smoke test
 
@@ -177,5 +197,6 @@ After all test lanes pass, two additional steps are required before complete acc
 ## References
 
 - Fuzzer protocol: [`../fuzz-proto/README.md`](../fuzz-proto/README.md), [`../fuzz-proto/fuzz-v1.asn`](../fuzz-proto/fuzz-v1.asn)
+- JAM test vectors: https://github.com/davxy/jam-test-vectors
 - JAM tiny profile: https://docs.jamcha.in/basics/chain-spec/tiny
 - JAM full profile: https://docs.jamcha.in/basics/chain-spec/full

--- a/conformance-criteria/conformance-matrix.md
+++ b/conformance-criteria/conformance-matrix.md
@@ -27,15 +27,28 @@ Date: 2026-05-05
 
 The fuzzer parameters for each lane are defined in `fuzzer_configs/`.
 
+## Acceptance Criteria
+
+### Known test vectors
+
+- 100% pass of the required known vectors.
+- Any mismatch is a hard conformance failure.
+- Self-assessed by the implementor; no explicit assessment performed during evaluation.
+
+### Fuzzer-driven lanes (L0–L3)
+
+For every step of a session, the target's response must match the fuzzer's expected outcome:
+
+- If the (possibly mutated) block is valid: the target imports it and the resulting post-state root matches the expected post-state root.
+- If the (possibly mutated) block is invalid: the target rejects it with an Error response. The specific error variant is not required to match — only that the target rejects.
+
+Every session must additionally reach its configured `max_steps`.
+
+The wire-level message exchange (block submission, import / state-root / error responses) is defined by the fuzzer protocol; see [`../fuzz-proto/README.md`](../fuzz-proto/README.md) and [`../fuzz-proto/fuzz-v1.asn`](../fuzz-proto/fuzz-v1.asn).
+
 ## Known Test Vectors
 
 Run implementation against all published and well-known test vectors.
-
-### Acceptance Criteria
-
-- 100% pass of required known vectors.
-- Any mismatch is a hard conformance failure.
-- Self-assessed by the implementor; no explicit assessment performed during evaluation.
 
 ## L0 -- Smoke test
 
@@ -46,14 +59,9 @@ Source: `fuzzer_configs/l0_tiny.toml`
 | jam_spec | tiny |
 | profile | empty |
 | max_mutations | 0 |
-| max_steps | 100 |
+| max_steps | 32 |
 | safrole | false |
 | skip_slots | false |
-
-### Acceptance Criteria
-
-- Target accepts trace input and produces matching state roots.
-- Session reaches `max_steps`.
 
 ## L1 -- Happy-path import
 
@@ -88,11 +96,6 @@ Source: `fuzzer_configs/l1_full.toml`
 | max_steps | 100000 |
 | safrole | false |
 | skip_slots | false |
-
-### Acceptance Criteria (L1a/L1b)
-
-- Expected state root matches target state root on every step.
-- Session reaches `max_steps`.
 
 ## L2 -- Mutations
 
@@ -130,11 +133,6 @@ Source: `fuzzer_configs/l2_full.toml`
 | safrole | false |
 | skip_slots | false |
 
-### Acceptance Criteria (L2a/L2b)
-
-- Expected state root matches target state root on every step.
-- Session reaches `max_steps`.
-
 ## L3 -- Safrole
 
 Both sub-runs enable Safrole and run with `skip_slots = false`.
@@ -169,11 +167,6 @@ Source: `fuzzer_configs/l3_full.toml`
 | max_steps | 100000 |
 | skip_slots | false |
 
-### Acceptance Criteria (L3a/L3b)
-
-- Expected state root matches target state root on every step.
-- Session reaches `max_steps`.
-
 ## Final Acceptance
 
 After all test lanes pass, two additional steps are required before complete acceptance:
@@ -183,5 +176,6 @@ After all test lanes pass, two additional steps are required before complete acc
 
 ## References
 
+- Fuzzer protocol: [`../fuzz-proto/README.md`](../fuzz-proto/README.md), [`../fuzz-proto/fuzz-v1.asn`](../fuzz-proto/fuzz-v1.asn)
 - JAM tiny profile: https://docs.jamcha.in/basics/chain-spec/tiny
 - JAM full profile: https://docs.jamcha.in/basics/chain-spec/full

--- a/conformance-criteria/conformance-run-matrix.md
+++ b/conformance-criteria/conformance-run-matrix.md
@@ -1,6 +1,6 @@
 # Conformance Run Matrix (Proposed)
 
-Date: 2026-03-16
+Date: 2026-05-05
 
 ## Goals
 
@@ -14,15 +14,22 @@ Date: 2026-03-16
 - The test programme is divided in different lanes and teams have to pass all of them.
 
 - Lanes:
-    * L1 -- Known Test Vectors: run implementation against all published and well-known test vectors.
-    * L2 -- Mutations: testing happy-path import and mutation/error handling, without Safrole.
-        - L2a -- Tiny profile (1M steps, 5 work items)
-        - L2b -- Full profile (10K steps, 16 work items)
-    * L3 -- Safrole: exercising Safrole with slot-skipping, no mutations.
-        - L3a -- Tiny profile (10K steps)
-        - L3b -- Full profile (10K steps)
+    * L0 -- Smoke test: minimal sanity run on the tiny spec.
+    * L1 -- Happy-path import: import without mutations or Safrole.
+        - L1a -- Tiny spec
+        - L1b -- Full spec
+    * L2 -- Mutations: happy-path import together with mutation/error handling, without Safrole.
+        - L2a -- Tiny spec
+        - L2b -- Full spec
+    * L3 -- Safrole: exercise Safrole, no mutations.
+        - L3a -- `validators-management` workload
+        - L3b -- empty workload
 
-## L1 -- Known Test Vectors
+The fuzzer parameters for each lane are defined in `fuzzer_configs/`.
+
+## Known Test Vectors
+
+Run implementation against all published and well-known test vectors.
 
 ### Acceptance Criteria
 
@@ -30,15 +37,76 @@ Date: 2026-03-16
 - Any mismatch is a hard conformance failure.
 - Self-assessed by the implementor; no explicit assessment performed during evaluation.
 
+## L0 -- Smoke test
+
+Source: `fuzzer_configs/l0_tiny.toml`
+
+| Parameter | Value |
+|-----------|-------|
+| jam_spec | tiny |
+| profile | empty |
+| max_mutations | 0 |
+| max_steps | 100 |
+| safrole | false |
+| skip_slots | false |
+
+### Acceptance Criteria
+
+- Target accepts trace input and produces matching state roots.
+- Session reaches `max_steps`.
+
+## L1 -- Happy-path import
+
+Import without mutations and without Safrole.
+
+### L1a -- Tiny
+
+Source: `fuzzer_configs/l1_tiny.toml`
+
+| Parameter | Value |
+|-----------|-------|
+| jam_spec | tiny |
+| profile | full |
+| fuzzy_profile | full |
+| max_mutations | 0 |
+| max_work_items | 5 |
+| max_steps | 100000 |
+| safrole | false |
+| skip_slots | false |
+| seeds | 10 random |
+
+### L1b -- Full
+
+Source: `fuzzer_configs/l1_full.toml`
+
+| Parameter | Value |
+|-----------|-------|
+| jam_spec | full |
+| profile | full |
+| fuzzy_profile | full |
+| max_mutations | 0 |
+| max_work_items | 5 |
+| max_steps | 100000 |
+| safrole | false |
+| skip_slots | false |
+| seeds | 10 random |
+
+### Acceptance Criteria (L1a/L1b)
+
+- Expected state root matches target state root on every step.
+- Session reaches `max_steps`.
+
 ## L2 -- Mutations
 
 Testing both happy-path import and mutation/error handling, without Safrole.
 
 ### L2a -- Tiny
 
+Source: `fuzzer_configs/l2_tiny.toml`
+
 | Parameter | Value |
 |-----------|-------|
-| jam_profile | full |
+| jam_spec | tiny |
 | profile | full |
 | fuzzy_profile | full |
 | max_mutations | 5 |
@@ -51,15 +119,17 @@ Testing both happy-path import and mutation/error handling, without Safrole.
 
 ### L2b -- Full
 
+Source: `fuzzer_configs/l2_full.toml`
+
 | Parameter | Value |
 |-----------|-------|
-| jam_profile | full |
+| jam_spec | full |
 | profile | full |
 | fuzzy_profile | full |
 | max_mutations | 5 |
 | mutation_ratio | 0.1 |
-| max_work_items | 16 |
-| max_steps | 10000 |
+| max_work_items | 5 |
+| max_steps | 1000000 |
 | safrole | false |
 | skip_slots | false |
 | seeds | 10 random |
@@ -71,36 +141,38 @@ Testing both happy-path import and mutation/error handling, without Safrole.
 
 ## L3 -- Safrole
 
-Two sub-runs escalating from minimal to full profiles. Both enable `skip_slots` alongside `safrole`.
+Both sub-runs enable Safrole and run with `skip_slots = false`.
 
-### L3a -- Tiny
+### L3a -- `validators-management` workload
+
+Source: `fuzzer_configs/l3_tiny.toml`
 
 | Parameter | Value |
 |-----------|-------|
-| jam_profile | tiny |
+| jam_spec | tiny |
+| profile | validators-management |
+| fuzzy_profile | empty |
+| safrole | true |
+| max_mutations | 0 |
+| max_work_items | 3 |
+| max_steps | 100000 |
+| skip_slots | false |
+| seeds | 10 random |
+
+### L3b -- empty workload
+
+Source: `fuzzer_configs/l3_full.toml`
+
+| Parameter | Value |
+|-----------|-------|
+| jam_spec | tiny |
 | profile | empty |
 | fuzzy_profile | empty |
 | safrole | true |
-| max_mutations | 0 (forced) |
-| mutation_ratio | 0.0 |
+| max_mutations | 0 |
 | max_work_items | 0 |
-| max_steps | 10000 |
-| skip_slots | true |
-| seeds | 10 random |
-
-### L3b -- Full
-
-| Parameter | Value |
-|-----------|-------|
-| jam_profile | full |
-| profile | full |
-| fuzzy_profile | full |
-| safrole | true |
-| max_mutations | 0 (forced) |
-| mutation_ratio | 0.0 |
-| max_work_items | 5 |
-| max_steps | 10000 |
-| skip_slots | true |
+| max_steps | 100000 |
+| skip_slots | false |
 | seeds | 10 random |
 
 ### Acceptance Criteria (L3a/L3b)

--- a/conformance-criteria/fuzzer_configs/default.toml
+++ b/conformance-criteria/fuzzer_configs/default.toml
@@ -1,0 +1,163 @@
+# PolkaJam Fuzzer Configuration
+#
+# CLI arguments take precedence over settings in this file.
+# See `--help` for all available options.
+
+################################################################################
+# Core Settings
+################################################################################
+
+# Random number generator seed
+# Formats:
+#   - Hex: 0x followed by 64 hex characters (32 bytes)
+#   - Passphrase: Any string (hashed to produce seed)
+# [default: randomly generated]
+seed = "42"
+
+# Block data source for fuzzing
+# Options:
+#   - local: Internal block authoring engine
+#   - remote: Import from remote node via socket
+#   - trace: Replay pre-recorded traces
+# [default: local]
+source = "local"
+
+# JAM protocol specification variant
+# Options:
+#   - tiny: Smaller parameters for faster testing
+#   - full: Full production parameters
+# [default: tiny]
+jam_spec = "tiny"
+
+# Directory for execution traces
+# Usage depends on source:
+#   - local/remote: Output directory for generated traces
+#   - trace: Input directory (required)
+trace_dir = "traces"
+
+# Unix domain socket path for remote block source.
+# Receives blocks from a remote source for validation.
+# Only used when `source = "remote"`.
+# [default: none]
+# source_sock = "/tmp/jam_source.sock"
+
+# Unix domain socket path for remote conformance testing target.
+# Sends blocks to a remote target and compares state transitions
+# to validate implementation consistency.
+# [default: none]
+# target_sock = "/tmp/jam_target.sock"
+
+# Delay between fuzzing steps (milliseconds)
+# Actual duration may be longer if operations take time
+# [default: 1000]
+step_period = 100
+
+# Maximum number of steps
+# May terminate earlier on unrecoverable errors.
+# Note: Step count ≠ imported blocks (some may be invalid)
+# [default: unlimited]
+max_steps = 10000
+
+################################################################################
+# Fuzzing Behavior
+################################################################################
+
+# Enable Safrole consensus for block authoring
+# Disabling improves fuzzing speed
+# [default: false]
+safrole = false
+
+# Randomly skip slots during block authoring
+# [default: false]
+skip_slots = false
+
+# Pause after each step waiting for user input
+# [default: false]
+single_step = false
+
+# Work item execution profile
+# Controls which work item types are processed:
+#   - empty: No work items
+#   - full: All types (default)
+#   - storage: Storage operations only
+#   - preimages: Preimage operations only
+#   - management: Management operations only
+#   - validators_management: Validator management only
+# [default: full]
+profile = "full"
+
+# Fuzzy service instruction profile
+# Selects which PVM instructions are enabled in the fuzzy service:
+#   - mem-check: Memory validation
+#   - storage: Storage operations
+#   - preimages: Preimage operations
+#   - management: Service management
+#   - services: Service invocations
+#   - misc: Miscellaneous operations
+#   - full: All instructions (default)
+# [default: full]
+fuzzy_profile = "full"
+
+# Maximum work items per package
+# [default: 5]
+max_work_items = 5
+
+# Probability of applying mutations (0.0 - 1.0)
+# 0.0 = no mutations, 1.0 = always mutate
+# [default: 0.0]
+mutation_ratio = 0.1
+
+# Maximum mutations generated per block
+# Set to 0 to disable mutations
+# [default: 0]
+max_mutations = 5
+
+################################################################################
+# Output & Diagnostics
+################################################################################
+
+# Logging verbosity level (0-3)
+# Levels:
+#   - 0: Basic fuzzer logs
+#   - 1: Detailed fuzzer logs
+#   - 2: Backend logs (PVM, Safrole, etc.)
+#   - 3: On-chain statistics and auxiliary info
+# [default: 0]
+verbosity = 2
+
+# Log output file path
+# If not specified, logs are not persisted
+# [default: none]
+log_file = "fuzz.log"
+
+# Display configuration and exit without fuzzing
+# [default: false]
+show_config = false
+
+# Pause on non-fatal errors
+# [default: false]
+pause_on_error = false
+
+# Persist traces when replaying existing traces
+# When source is "trace", traced replays are normally not saved
+# Enabling this saves them to {trace_dir}_new
+# [default: false]
+trace_traces = false
+
+################################################################################
+# Advanced
+################################################################################
+
+# Use PVM interpreter instead of recompiler
+# [default: false]
+pvm_interpreter_backend = true
+
+# Remote operations timeout (seconds)
+# Maximum wait time for remote socket operations
+# [default: 30]
+remote_timeout = 30
+
+# Link overhead for remote target operations (microseconds)
+# Time overhead to account for in remote block import measurements
+# [default: 500]
+link_overhead = 500

--- a/conformance-criteria/fuzzer_configs/l0_tiny.toml
+++ b/conformance-criteria/fuzzer_configs/l0_tiny.toml
@@ -1,11 +1,11 @@
 # L0 -- Smoke test (tiny spec)
 #
-# Minimal sanity run: 100 steps, empty workload, no mutations, no Safrole.
+# Minimal sanity run: 32 steps, empty workload, no mutations, no Safrole.
 
 jam_spec = "tiny"
 profile = "empty"
 safrole = false
-max_steps = 100
+max_steps = 32
 max_work_items = 0
 max_mutations = 0
 # 15 seconds timeout

--- a/conformance-criteria/fuzzer_configs/l0_tiny.toml
+++ b/conformance-criteria/fuzzer_configs/l0_tiny.toml
@@ -2,25 +2,25 @@
 #
 # Minimal sanity run: 100 steps, empty workload, no mutations, no Safrole.
 
-source = "local"
 jam_spec = "tiny"
-max_steps = 100
 profile = "empty"
+safrole = false
+max_steps = 100
 max_work_items = 0
 max_mutations = 0
+# 15 seconds timeout
 remote_timeout = 15
-log_file = "fuzz.log"
-pvm_interpreter_backend = true
-
-# If required, overwrite via `--target-sock` CLI option
-target_sock = "/tmp/jam_fuzz/fuzz.sock"
 
 # Shared
+source = "local"
+# Overwrite via `--target-sock` CLI option if required
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
 step_period = 0
 verbosity = 2
 trace_dir = "traces"
-safrole = false
 skip_slots = false
 single_step = false
+show_config = false
 pause_on_error = false
 trace_traces = false
+pvm_interpreter_backend = true

--- a/conformance-criteria/fuzzer_configs/l0_tiny.toml
+++ b/conformance-criteria/fuzzer_configs/l0_tiny.toml
@@ -1,0 +1,26 @@
+# L0 -- Smoke test (tiny spec)
+#
+# Minimal sanity run: 100 steps, empty workload, no mutations, no Safrole.
+
+source = "local"
+jam_spec = "tiny"
+max_steps = 100
+profile = "empty"
+max_work_items = 0
+max_mutations = 0
+remote_timeout = 15
+log_file = "fuzz.log"
+pvm_interpreter_backend = true
+
+# If required, overwrite via `--target-sock` CLI option
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
+
+# Shared
+step_period = 0
+verbosity = 2
+trace_dir = "traces"
+safrole = false
+skip_slots = false
+single_step = false
+pause_on_error = false
+trace_traces = false

--- a/conformance-criteria/fuzzer_configs/l1_full.toml
+++ b/conformance-criteria/fuzzer_configs/l1_full.toml
@@ -1,29 +1,26 @@
 # L1 -- Happy-path import (full spec)
 #
-# 100K steps, full workload, no mutations, no Safrole.
-# Acceptance: state roots match on every step; run reaches `max_steps`.
-
-source = "local"
+# 100K steps, workload, no mutations, no Safrole.
 
 jam_spec = "full"
 profile = "full"
 fuzzy_profile = "full"
+safrole = false
 max_steps = 100000
 max_work_items = 5
 max_mutations = 0
+# Use u32::max to enable target pause/resume
 remote_timeout = 4294967295
 
-# If required, overwrite via `--target-sock` CLI option
-target_sock = "/tmp/jam_fuzz/fuzz.sock"
-
 # Shared
+source = "local"
+# Overwrite via `--target-sock` CLI option if required
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
 step_period = 0
 verbosity = 2
 trace_dir = "traces"
-safrole = false
 skip_slots = false
 single_step = false
-log_file = "fuzz.log"
 show_config = false
 pause_on_error = false
 trace_traces = false

--- a/conformance-criteria/fuzzer_configs/l1_full.toml
+++ b/conformance-criteria/fuzzer_configs/l1_full.toml
@@ -1,0 +1,30 @@
+# L1 -- Happy-path import (full spec)
+#
+# 100K steps, full workload, no mutations, no Safrole.
+# Acceptance: state roots match on every step; run reaches `max_steps`.
+
+source = "local"
+
+jam_spec = "full"
+profile = "full"
+fuzzy_profile = "full"
+max_steps = 100000
+max_work_items = 5
+max_mutations = 0
+remote_timeout = 4294967295
+
+# If required, overwrite via `--target-sock` CLI option
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
+
+# Shared
+step_period = 0
+verbosity = 2
+trace_dir = "traces"
+safrole = false
+skip_slots = false
+single_step = false
+log_file = "fuzz.log"
+show_config = false
+pause_on_error = false
+trace_traces = false
+pvm_interpreter_backend = true

--- a/conformance-criteria/fuzzer_configs/l1_tiny.toml
+++ b/conformance-criteria/fuzzer_configs/l1_tiny.toml
@@ -1,31 +1,26 @@
 # L1 -- Happy-path import (tiny spec)
 #
-# 100K steps, full workload, no mutations, no Safrole.
-# Acceptance: state roots match on every step; run reaches `max_steps`.
-
-source = "local"
+# 100K steps, workload, no mutations, no Safrole.
 
 jam_spec = "tiny"
 profile = "full"
 fuzzy_profile = "full"
+safrole = false
 max_steps = 100000
 max_work_items = 5
 max_mutations = 0
+# Use u32::max to enable target pause/resume
 remote_timeout = 4294967295
 
-# If required, overwrite via `--target-sock` CLI option
-target_sock = "/tmp/jam_fuzz/fuzz.sock"
-
 # Shared
+source = "local"
+# Overwrite via `--target-sock` CLI option if required
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
 step_period = 0
 verbosity = 2
-
-# As per default
 trace_dir = "traces"
-safrole = false
 skip_slots = false
 single_step = false
-log_file = "fuzz.log"
 show_config = false
 pause_on_error = false
 trace_traces = false

--- a/conformance-criteria/fuzzer_configs/l1_tiny.toml
+++ b/conformance-criteria/fuzzer_configs/l1_tiny.toml
@@ -1,0 +1,32 @@
+# L1 -- Happy-path import (tiny spec)
+#
+# 100K steps, full workload, no mutations, no Safrole.
+# Acceptance: state roots match on every step; run reaches `max_steps`.
+
+source = "local"
+
+jam_spec = "tiny"
+profile = "full"
+fuzzy_profile = "full"
+max_steps = 100000
+max_work_items = 5
+max_mutations = 0
+remote_timeout = 4294967295
+
+# If required, overwrite via `--target-sock` CLI option
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
+
+# Shared
+step_period = 0
+verbosity = 2
+
+# As per default
+trace_dir = "traces"
+safrole = false
+skip_slots = false
+single_step = false
+log_file = "fuzz.log"
+show_config = false
+pause_on_error = false
+trace_traces = false
+pvm_interpreter_backend = true

--- a/conformance-criteria/fuzzer_configs/l2_full.toml
+++ b/conformance-criteria/fuzzer_configs/l2_full.toml
@@ -1,14 +1,11 @@
 # L2 -- Mutations (full spec)
 #
-# 1M steps, full workload, 5 mutations per block at ratio 0.1, no Safrole.
-# Exercises happy-path import together with mutation/error handling.
-# Acceptance: state roots match on every step; run reaches `max_steps`.
-
-source = "local"
+# 1M steps, workload, mutations, no Safrole.
 
 jam_spec = "full"
 profile = "full"
 fuzzy_profile = "full"
+safrole = false
 max_steps = 1000000
 max_work_items = 5
 max_mutations = 5
@@ -16,19 +13,16 @@ mutation_ratio = 0.1
 # Use u32::max to enable target pause/resume
 remote_timeout = 4294967295
 
-# If required, overwrite via `--target-sock` CLI option
-target_sock = "/tmp/jam_fuzz/fuzz.sock"
-
 # Shared
+source = "local"
+# Overwrite via `--target-sock` CLI option if required
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
 step_period = 0
 verbosity = 2
-
-# As per default
 trace_dir = "traces"
-safrole = false
+log_file = "fuzz.log"
 skip_slots = false
 single_step = false
-log_file = "fuzz.log"
 show_config = false
 pause_on_error = false
 trace_traces = false

--- a/conformance-criteria/fuzzer_configs/l2_full.toml
+++ b/conformance-criteria/fuzzer_configs/l2_full.toml
@@ -1,0 +1,35 @@
+# L2 -- Mutations (full spec)
+#
+# 1M steps, full workload, 5 mutations per block at ratio 0.1, no Safrole.
+# Exercises happy-path import together with mutation/error handling.
+# Acceptance: state roots match on every step; run reaches `max_steps`.
+
+source = "local"
+
+jam_spec = "full"
+profile = "full"
+fuzzy_profile = "full"
+max_steps = 1000000
+max_work_items = 5
+max_mutations = 5
+mutation_ratio = 0.1
+# Use u32::max to enable target pause/resume
+remote_timeout = 4294967295
+
+# If required, overwrite via `--target-sock` CLI option
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
+
+# Shared
+step_period = 0
+verbosity = 2
+
+# As per default
+trace_dir = "traces"
+safrole = false
+skip_slots = false
+single_step = false
+log_file = "fuzz.log"
+show_config = false
+pause_on_error = false
+trace_traces = false
+pvm_interpreter_backend = true

--- a/conformance-criteria/fuzzer_configs/l2_tiny.toml
+++ b/conformance-criteria/fuzzer_configs/l2_tiny.toml
@@ -1,14 +1,11 @@
 # L2 -- Mutations (tiny spec)
 #
-# 1M steps, full workload, 5 mutations per block at ratio 0.1, no Safrole.
-# Exercises happy-path import together with mutation/error handling.
-# Acceptance: state roots match on every step; run reaches `max_steps`.
-
-source = "local"
+# 1M steps, workload, mutations, no Safrole.
 
 jam_spec = "tiny"
 profile = "full"
 fuzzy_profile = "full"
+safrole = false
 max_steps = 1000000
 max_work_items = 5
 max_mutations = 5
@@ -16,19 +13,16 @@ mutation_ratio = 0.1
 # Use u32::max to enable target pause/resume
 remote_timeout = 4294967295
 
-# If required, overwrite via `--target-sock` CLI option
-target_sock = "/tmp/jam_fuzz/fuzz.sock"
-
 # Shared
+source = "local"
+# Overwrite via `--target-sock` CLI option if required
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
 step_period = 0
 verbosity = 2
-
-# As per default
 trace_dir = "traces"
-safrole = false
+log_file = "fuzz.log"
 skip_slots = false
 single_step = false
-log_file = "fuzz.log"
 show_config = false
 pause_on_error = false
 trace_traces = false

--- a/conformance-criteria/fuzzer_configs/l2_tiny.toml
+++ b/conformance-criteria/fuzzer_configs/l2_tiny.toml
@@ -1,0 +1,35 @@
+# L2 -- Mutations (tiny spec)
+#
+# 1M steps, full workload, 5 mutations per block at ratio 0.1, no Safrole.
+# Exercises happy-path import together with mutation/error handling.
+# Acceptance: state roots match on every step; run reaches `max_steps`.
+
+source = "local"
+
+jam_spec = "tiny"
+profile = "full"
+fuzzy_profile = "full"
+max_steps = 1000000
+max_work_items = 5
+max_mutations = 5
+mutation_ratio = 0.1
+# Use u32::max to enable target pause/resume
+remote_timeout = 4294967295
+
+# If required, overwrite via `--target-sock` CLI option
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
+
+# Shared
+step_period = 0
+verbosity = 2
+
+# As per default
+trace_dir = "traces"
+safrole = false
+skip_slots = false
+single_step = false
+log_file = "fuzz.log"
+show_config = false
+pause_on_error = false
+trace_traces = false
+pvm_interpreter_backend = true

--- a/conformance-criteria/fuzzer_configs/l3_full.toml
+++ b/conformance-criteria/fuzzer_configs/l3_full.toml
@@ -1,8 +1,8 @@
-# L3 -- Safrole (tiny spec, empty workload)
+# L3 -- Safrole (full spec, empty workload)
 #
 # 100K steps with Safrole enabled, no work items, no mutations.
 
-jam_spec = "tiny"
+jam_spec = "full"
 profile = "empty"
 fuzzy_profile = "empty"
 safrole = true

--- a/conformance-criteria/fuzzer_configs/l3_full.toml
+++ b/conformance-criteria/fuzzer_configs/l3_full.toml
@@ -1,32 +1,27 @@
 # L3 -- Safrole (tiny spec, empty workload)
 #
 # 100K steps with Safrole enabled, no work items, no mutations.
-# Exercises Safrole slot/epoch transitions on a minimal workload.
-# Acceptance: state roots match on every step; run reaches `max_steps`.
-
-source = "local"
 
 jam_spec = "tiny"
 profile = "empty"
 fuzzy_profile = "empty"
+safrole = true
 max_steps = 100000
 max_work_items = 0
 max_mutations = 0
+# Use u32::max to enable target pause/resume
 remote_timeout = 4294967295
-safrole = true
-
-# If required, overwrite via `--target-sock` CLI option
-target_sock = "/tmp/jam_fuzz/fuzz.sock"
 
 # Shared
+source = "local"
+# Overwrite via `--target-sock` CLI option if required
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
 step_period = 0
 verbosity = 2
-
-# As per default
 trace_dir = "traces"
+log_file = "fuzz.log"
 skip_slots = false
 single_step = false
-log_file = "fuzz.log"
 show_config = false
 pause_on_error = false
 trace_traces = false

--- a/conformance-criteria/fuzzer_configs/l3_full.toml
+++ b/conformance-criteria/fuzzer_configs/l3_full.toml
@@ -1,0 +1,33 @@
+# L3 -- Safrole (tiny spec, empty workload)
+#
+# 100K steps with Safrole enabled, no work items, no mutations.
+# Exercises Safrole slot/epoch transitions on a minimal workload.
+# Acceptance: state roots match on every step; run reaches `max_steps`.
+
+source = "local"
+
+jam_spec = "tiny"
+profile = "empty"
+fuzzy_profile = "empty"
+max_steps = 100000
+max_work_items = 0
+max_mutations = 0
+remote_timeout = 4294967295
+safrole = true
+
+# If required, overwrite via `--target-sock` CLI option
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
+
+# Shared
+step_period = 0
+verbosity = 2
+
+# As per default
+trace_dir = "traces"
+skip_slots = false
+single_step = false
+log_file = "fuzz.log"
+show_config = false
+pause_on_error = false
+trace_traces = false
+pvm_interpreter_backend = true

--- a/conformance-criteria/fuzzer_configs/l3_tiny.toml
+++ b/conformance-criteria/fuzzer_configs/l3_tiny.toml
@@ -1,0 +1,34 @@
+# L3 -- Safrole (tiny spec, validators-management workload)
+#
+# 100K steps with Safrole enabled, 3 work items per block, no mutations.
+# Exercises Safrole slot/epoch transitions and validator set rotation.
+# Acceptance: state roots match on every step; run reaches `max_steps`.
+
+source = "local"
+
+jam_spec = "tiny"
+# profile = "full"
+profile = "validators-management"
+fuzzy_profile = "empty"
+max_steps = 100000
+max_work_items = 3
+max_mutations = 0
+remote_timeout = 4294967295
+safrole = true
+skip_slots = false
+
+# If required, overwrite via `--target-sock` CLI option
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
+
+# Shared
+step_period = 0
+verbosity = 2
+
+# As per default
+trace_dir = "traces"
+single_step = false
+log_file = "fuzz.log"
+show_config = false
+pause_on_error = false
+trace_traces = false
+pvm_interpreter_backend = true

--- a/conformance-criteria/fuzzer_configs/l3_tiny.toml
+++ b/conformance-criteria/fuzzer_configs/l3_tiny.toml
@@ -1,33 +1,27 @@
 # L3 -- Safrole (tiny spec, validators-management workload)
 #
 # 100K steps with Safrole enabled, 3 work items per block, no mutations.
-# Exercises Safrole slot/epoch transitions and validator set rotation.
-# Acceptance: state roots match on every step; run reaches `max_steps`.
-
-source = "local"
 
 jam_spec = "tiny"
-# profile = "full"
 profile = "validators-management"
 fuzzy_profile = "empty"
+safrole = true
 max_steps = 100000
 max_work_items = 3
 max_mutations = 0
+# Use u32::max to enable target pause/resume
 remote_timeout = 4294967295
-safrole = true
-skip_slots = false
-
-# If required, overwrite via `--target-sock` CLI option
-target_sock = "/tmp/jam_fuzz/fuzz.sock"
 
 # Shared
+source = "local"
+# Overwrite via `--target-sock` CLI option if required
+target_sock = "/tmp/jam_fuzz/fuzz.sock"
 step_period = 0
 verbosity = 2
-
-# As per default
 trace_dir = "traces"
-single_step = false
 log_file = "fuzz.log"
+skip_slots = false
+single_step = false
 show_config = false
 pause_on_error = false
 trace_traces = false

--- a/scripts/generate-report.py
+++ b/scripts/generate-report.py
@@ -12,10 +12,10 @@ The traces directory must contain the binary step files written by
 the fuzzer (genesis.bin and NNNNNNNN.bin, plus optionally report.bin).
 
 Steps are decoded from SCALE to JSON using the jam_types codecs and
-processed newest-first. With --report-prune, only a linear chain of
-ancestor blocks is kept (siblings whose parent matches the previously
-seen step are dropped). The walk stops once --report-depth distinct
-ancestors have been emitted (default 2).
+processed newest-first. With --prune, only a linear chain of ancestor
+blocks is kept (siblings whose parent matches the previously seen
+step are dropped). The walk stops once --depth distinct ancestors
+have been emitted (default 2).
 
 Decoded JSON and the matching .bin files land in ./report/ under the
 current working directory; report.bin, when present, is decoded into
@@ -57,24 +57,27 @@ def parse_command_line_args():
         help="Path to the directory containing the binary trace files",
     )
     parser.add_argument(
-        "-s",
-        "--report-depth",
+        "-d",
+        "--depth",
         type=int,
         default=2,
         help="Report chain depth (default: 2)",
     )
     parser.add_argument(
-        "--report-prune",
+        "-p",
+        "--prune",
         action="store_true",
         help="Exclude stale siblings from report chain",
     )
     parser.add_argument(
+        "-s",
         "--spec",
         default="tiny",
         choices=["tiny", "full"],
         help="Specification to use (default=tiny)",
     )
     parser.add_argument(
+        "-o",
         "--overwrite",
         action="store_true",
         help="Overwrite existing report directory if it exists",
@@ -128,19 +131,15 @@ def process_report_file(source_dir, dest_dir):
         return False
 
 
-def generate_report(session_trace_dir, session_report_dir, report_depth, report_prune):
+def generate_report(session_trace_dir, session_report_dir, depth, prune):
     """Generate a report from the traces collected in a session"""
-
-    if not os.path.exists(session_trace_dir):
-        print(f"Error: Traces directory does not exist: {session_trace_dir}")
-        exit(1)
 
     print("-----------------------------------------------")
     print("Generating report from traces...")
     print(f"* Report dir: {session_report_dir}")
     print(f"* Traces dir: {session_trace_dir}")
-    print(f"  - depth {report_depth}")
-    print(f"  - prune {report_prune}")
+    print(f"  - depth {depth}")
+    print(f"  - prune {prune}")
     print("-----------------------------------------------")
     print("")
 
@@ -163,8 +162,6 @@ def generate_report(session_trace_dir, session_report_dir, report_depth, report_
         input_file = os.path.join(session_trace_dir, f)
         print(f"* Processing: {input_file}")
 
-        shutil.copy(input_file, session_report_dir)
-
         if f == "genesis.bin":
             type = "Genesis"
         else:
@@ -176,9 +173,9 @@ def generate_report(session_trace_dir, session_report_dir, report_depth, report_
             print(f"Error converting {f} to JSON: {e}")
             continue
 
-        # If `report-prune` option is enabled, we require the final output to
-        # be a linear series of blocks, in which each step holds the parent
-        # block of the following step.
+        # If `prune` option is enabled, we require the final output to be a
+        # linear series of blocks, in which each step holds the parent block
+        # of the following step.
         if type != "Genesis":
             with open(tmp_file, "r") as json_file:
                 try:
@@ -187,24 +184,22 @@ def generate_report(session_trace_dir, session_report_dir, report_depth, report_
                     print(f"Error loading JSON from {tmp_file}: {e}")
                     continue
 
-            curr_parent_hash = data.get("block", {}).get("header", "{}").get("parent", "")
+            curr_parent_hash = data.get("block", {}).get("header", {}).get("parent", "")
 
             # For the first file, initialize parent_root
             if curr_parent_hash == parent_hash:
-                if report_prune:
+                if prune:
                     print(f"Skipping sibling {f}")
                     continue
             else:
                 head_ancestry_depth += 1
                 parent_hash = curr_parent_hash
 
-            with open(tmp_file, "r") as json_file:
-                data = json.load(json_file)
-
+        shutil.copy(input_file, session_report_dir)
         output_file = os.path.join(session_report_dir, f"{f[:-4]}.json")
         shutil.copy(tmp_file, output_file)
 
-        if head_ancestry_depth >= report_depth:
+        if head_ancestry_depth >= depth:
             break
 
     if os.path.exists(tmp_file):
@@ -249,8 +244,8 @@ def main():
     generate_report(
         session_trace_dir,
         session_report_dir,
-        args.report_depth,
-        args.report_prune
+        args.depth,
+        args.prune
     )
 
     print("")

--- a/scripts/generate-report.py
+++ b/scripts/generate-report.py
@@ -1,17 +1,32 @@
 #!/usr/bin/env python3
 
-# Generate reports from existing session folders.
-# This script takes a session folder and regenerates reports from the traces found there.
-# It mimics the report generation logic from fuzz-workflow.py but works on existing sessions.
+"""
+Regenerate a fuzzer report from a previously captured traces folder,
+without rerunning the fuzzer. This is the report-generation logic from
+fuzz-workflow.py extracted to operate on existing trace data.
 
-# example command: scripts/.venv/bin/python3 scripts/generate-session-reports.py scripts/sessions/<session-number> --spec tiny
-# (target is auto-detected from logs, but can be overridden with --target)
+Usage:
+    scripts/generate-report.py <traces-dir> --spec <tiny/full>
+
+The traces directory must contain the binary step files written by
+the fuzzer (genesis.bin and NNNNNNNN.bin, plus optionally report.bin).
+
+Steps are decoded from SCALE to JSON using the jam_types codecs and
+processed newest-first. With --report-prune, only a linear chain of
+ancestor blocks is kept (siblings whose parent matches the previously
+seen step are dropped). The walk stops once --report-depth distinct
+ancestors have been emitted (default 2).
+
+Decoded JSON and the matching .bin files land in ./report/ under the
+current working directory; report.bin, when present, is decoded into
+report.json there as well. Pass --overwrite to replace an existing
+report directory.
+"""
 
 import json
 import os
 import re
 import shutil
-import sys
 import tempfile
 import argparse
 
@@ -19,21 +34,15 @@ from jam_types import ScaleBytes
 from jam_types import spec
 from jam_types.fuzzer import Genesis, TraceStep, FuzzerReport
 
-# Set JAM_CONFORMANCE_DIR relative to the script's actual location
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-JAM_CONFORMANCE_DIR = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
-
-DEFAULT_GP_VERSION = "0.7.2"
-
 
 def parse_command_line_args():
     parser = argparse.ArgumentParser(
-        description="Generate reports from existing session folders"
+        description="Generate a report from an existing traces folder"
     )
     parser.add_argument(
-        "session_dir",
+        "traces_dir",
         type=str,
-        help="Path to the session directory containing traces",
+        help="Path to the directory containing the binary trace files",
     )
     parser.add_argument(
         "-s",
@@ -46,23 +55,6 @@ def parse_command_line_args():
         "--report-prune",
         action="store_true",
         help="Exclude stale siblings from report chain",
-    )
-    parser.add_argument(
-        "--report-publish",
-        action="store_true",
-        help="Publish report to JAM_CONFORMANCE_DIR",
-    )
-    parser.add_argument(
-        "--gp-version",
-        type=str,
-        default=DEFAULT_GP_VERSION,
-        help=f"Gray Paper version (default: {DEFAULT_GP_VERSION})",
-    )
-    parser.add_argument(
-        "--target",
-        type=str,
-        default=None,
-        help="Target name (auto-detected from logs if not specified)",
     )
     parser.add_argument(
         "--spec",
@@ -209,72 +201,6 @@ def generate_report(session_trace_dir, session_report_dir, report_depth, report_
     process_report_file(session_trace_dir, session_report_dir)
 
 
-def detect_target_from_logs(session_dir):
-    """Auto-detect target name from log filenames"""
-    logs_dir = os.path.join(session_dir, "logs")
-
-    if not os.path.exists(logs_dir):
-        return None
-
-    # Look for fuzzer_*.log or target_*.log files
-    log_files = os.listdir(logs_dir)
-    for log_file in log_files:
-        # Match fuzzer_{target}.log or target_{target}.log
-        match = re.match(r'(?:fuzzer|target)_(.+)\.log$', log_file)
-        if match:
-            target = match.group(1)
-            print(f"Auto-detected target from logs: {target}")
-            return target
-
-    return None
-
-
-def publish_report_traces(session_report_dir, session_id, gp_version):
-    """Publish trace files to the jam-conformance directory"""
-    print("* Publish report traces")
-    dest_base = os.path.join(JAM_CONFORMANCE_DIR, "fuzz-reports", gp_version)
-    dest_dir = os.path.join(dest_base, "traces", session_id)
-
-    os.makedirs(dest_dir, exist_ok=True)
-
-    for f in os.listdir(session_report_dir):
-        if not (
-            re.match(r"\d{8}\.(bin|json)$", f) or re.match(r"genesis\.(bin|json)$", f)
-        ):
-            print(f"Skipping non-trace file {f}")
-            continue
-        print(f"Copying trace file {f} to {dest_dir}")
-        shutil.copy(os.path.join(session_report_dir, f), dest_dir)
-    print(f"Traces copied to {dest_dir}")
-
-
-def publish_report_report(session_report_dir, session_id, target, gp_version):
-    """Publish report files to the jam-conformance directory"""
-    print("* Publish report")
-    dest_base = os.path.join(JAM_CONFORMANCE_DIR, "fuzz-reports", gp_version)
-    dest_dir = os.path.join(dest_base, "reports", target, session_id)
-
-    os.makedirs(dest_dir, exist_ok=True)
-
-    for f in os.listdir(session_report_dir):
-        if f not in ["report.bin", "report.json"]:
-            continue
-        print(f"Copying report file {f} to {dest_dir}")
-        shutil.copy(os.path.join(session_report_dir, f), dest_dir)
-    print(f"Reports copied to {dest_dir}")
-
-
-def publish_report(session_report_dir, session_id, target, gp_version):
-    """Publish both traces and reports to jam-conformance"""
-    print("* Publishing report")
-    if not os.path.exists(session_report_dir):
-        print(f"Error: Report directory does not exist: {session_report_dir}")
-        exit(1)
-
-    publish_report_traces(session_report_dir, session_id, gp_version)
-    publish_report_report(session_report_dir, session_id, target, gp_version)
-
-
 def main():
     args = parse_command_line_args()
 
@@ -282,36 +208,18 @@ def main():
     print(f"Setting JAM spec: {args.spec}")
     spec.set_spec(args.spec)
 
-    # Validate session directory
-    session_dir = os.path.abspath(args.session_dir)
-    if not os.path.exists(session_dir):
-        print(f"Error: Session directory does not exist: {session_dir}")
-        exit(1)
-
-    if not os.path.isdir(session_dir):
-        print(f"Error: {session_dir} is not a directory")
-        exit(1)
-
-    # Get session ID from directory name
-    session_id = os.path.basename(session_dir)
-    print(f"Processing session: {session_id}")
-
-    # Auto-detect target if not specified
-    if args.target is None:
-        args.target = detect_target_from_logs(session_dir)
-        if args.target is None:
-            args.target = "unknown"
-            print("Warning: Could not auto-detect target from logs. Using 'unknown'.")
-
-    # Define directories
-    session_trace_dir = os.path.join(session_dir, "trace")
-    session_report_dir = os.path.join(session_dir, "report")
-
-    # Check if trace directory exists
+    # Validate traces directory
+    session_trace_dir = os.path.abspath(args.traces_dir)
     if not os.path.exists(session_trace_dir):
-        print(f"Error: Trace directory not found: {session_trace_dir}")
-        print(f"Expected structure: {session_dir}/trace/")
+        print(f"Error: Traces directory does not exist: {session_trace_dir}")
         exit(1)
+
+    if not os.path.isdir(session_trace_dir):
+        print(f"Error: {session_trace_dir} is not a directory")
+        exit(1)
+
+    # Report directory in the current working directory
+    session_report_dir = os.path.abspath("report")
 
     # Create or verify report directory
     if os.path.exists(session_report_dir):
@@ -336,21 +244,6 @@ def main():
     print("")
     print("✓ Report generation complete!")
     print(f"  Report directory: {session_report_dir}")
-
-    # Optionally publish the report
-    if args.report_publish:
-        if args.target == "unknown":
-            print("Warning: No target specified. Using 'unknown' as target name.")
-            print("Use --target to specify the correct target name for publishing.")
-
-        publish_report(
-            session_report_dir,
-            session_id,
-            args.target,
-            args.gp_version
-        )
-        print("✓ Report published!")
-
     print("")
 
 

--- a/scripts/generate-report.py
+++ b/scripts/generate-report.py
@@ -21,6 +21,14 @@ Decoded JSON and the matching .bin files land in ./report/ under the
 current working directory; report.bin, when present, is decoded into
 report.json there as well. Pass --overwrite to replace an existing
 report directory.
+
+Dependencies:
+    jam-types-py (https://github.com/davxy/jam-types-py) provides the
+    SCALE codecs used to decode traces. Producing a correct report for
+    a given Gray Paper version requires a matching jam-types-py
+    release: traces produced by a target implementing GP 0.7.2 must be
+    decoded with jam-types-py v0.7.2
+    (https://github.com/davxy/jam-types-py/releases/tag/v0.7.2).
 """
 
 import json

--- a/scripts/generate-report.py
+++ b/scripts/generate-report.py
@@ -45,7 +45,11 @@ from jam_types.fuzzer import Genesis, TraceStep, FuzzerReport
 
 def parse_command_line_args():
     parser = argparse.ArgumentParser(
-        description="Generate a report from an existing traces folder"
+        description=(
+            "Generate a report from an existing traces folder. "
+            "Requires jam-types-py (https://github.com/davxy/jam-types-py); "
+            "use a release matching the Gray Paper version of the traces."
+        )
     )
     parser.add_argument(
         "traces_dir",


### PR DESCRIPTION
Reworks the M1 conformance run matrix and tooling.

-  `conformance-matrix.md` defining the L0–L3 lane structure (smoke, happy-path import, mutations, Safrole) with explicit fuzzer parameters and acceptance criteria.
- Adds per-lane fuzzer configs under `conformance-criteria/fuzzer_configs/` (`default.toml` plus `l0_tiny`, `l1_{tiny,full}`, `l2_{tiny,full}`, `l3_{tiny,full}`) so each lane is reproducible from a checked-in TOML.
- `scripts/generate-report.py` for post-run report generation

