### PR TITLE
Add JOTL client implementation

### DIFF
--- a/scripts/targets.json
+++ b/scripts/targets.json
@@ -63,6 +63,10 @@
     "image": "ghcr.io/ascrivener/jamzilla:edge",
     "gp_version": "0.7.2"
   },
+  "jotl": {
+    "image": "ghcr.io/polykrate/jotl:latest",
+    "gp_version": "0.7.2"
+  },
   "javajam": {
     "image": "ghcr.io/methodfive/javajam:latest-amd64",
     "gp_version": "0.7.2"


### PR DESCRIPTION
Add JOTL (JAM On The Lisp) to the conformance targets.

**Image**: `ghcr.io/polykrate/jotl:latest`

Uses standard target packaging (`JAM_FUZZ*` env vars) — no `cmd` or `args` needed.

**GP version**: 0.7.2

Related issue: #196

Made with [Cursor](https://cursor.com)