### PR TITLE
chore(target): migrate the docker image of spacejam from docker to ghcr

### DIFF
--- a/scripts/targets.json
+++ b/scripts/targets.json
@@ -79,7 +79,7 @@
     "gp_version": "0.7.2"
   },
   "spacejam": {
-    "image": "docker.io/clearloop/spacejam:latest",
+    "image": "ghcr.io/spacejamapp/spacejam:latest",
     "gp_version": "0.7.2"
   },
   "strawberry": {


### PR DESCRIPTION
point our image here to `ghcr.io` as well to match what we are using rn in the fuzzer